### PR TITLE
add support for links

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,7 +2,6 @@
 /target/
 **/*.rs.bk
 .env
-test.md
 /target/
 **/*.rs.bk
 Cargo.lock

--- a/test.md
+++ b/test.md
@@ -1,0 +1,31 @@
+# Heading 1
+This is a top-level heading in red
+
+## Heading 2
+This is a secondary heading in blue
+
+### Heading 3
+This is a tertiary heading in green
+
+Regular text with **bold words** and *italic phrases*.
+
+You can also have **bold text that spans multiple words** and *italicized sections that continue across several terms*.
+
+Here's a link to [Rust's official website](https://www.rust-lang.org).
+
+Malformed links should appear as plain text: [just brackets] and [missing paren https://example.com.
+
+You can mix formats like **[bold link](https://example.com)** or *italic link [example](https://example.com)*.
+
+Edge cases:
+- Literal stars: 2 * 2 = 4
+- Literal brackets: array[0]
+- **bold*with*stars**
+- *italic*with*stars*
+- Empty formats: **** ** **
+- Nested formats: **bold *with italic*** and *italic **with bold***
+
+More links:
+- [Google](https://www.google.com)
+- [GitHub](https://github.com)
+- [Markdown Guide](https://www.markdownguide.org)


### PR DESCRIPTION
# og vs new version

## what's better

### accuracy
- handles punctuation inside *italic* or **bold** stuff
- better at finding where formatting starts/stops
- keeps all spaces exactly how they were

### speed
- uses less memory
- only reads the text once
- no temporary word lists hanging around

### code stuff
- easier to follow step by step
- different jobs separated better
- catches mistakes better

### what you see
- links can be clicked (if your terminal supports it)
- colors don't get messed up when nested
- always resets formatting properly

## side by side

*input:* `"check out [rust](https://rust-lang.org) for **cool** docs!"`

*og version:*
1. chops into 6 separate words
2. might get confused by the []()
3. does bold stuff by itself

*new version:*
- sees the whole link together
- keeps spacing perfect
- handles bold right next to links

## tradeoffs
- code is a bit harder to read
- gotta handle more weird cases
- more nested if/else stuff

## why it's better now
1. markdown often has formatting across multiple words
2. need to check each character carefully
3. terminal codes gotta be perfect